### PR TITLE
Make it work in linux

### DIFF
--- a/Externals/xbrz/xbrz.cpp
+++ b/Externals/xbrz/xbrz.cpp
@@ -389,10 +389,12 @@ template <> inline unsigned char rotateBlendInfo<ROT_180>(unsigned char b) { ret
 template <> inline unsigned char rotateBlendInfo<ROT_270>(unsigned char b) { return ((b << 6) | (b >> 2)) & 0xff; }
 
 
+#ifdef _WIN32
 #ifndef NDEBUG
 int debugPixelX = -1;
 int debugPixelY = 12;
 __declspec(thread) bool breakIntoDebugger = false;
+#endif
 #endif
 
 
@@ -423,9 +425,11 @@ void blendPixel(const Kernel_3x3& ker,
 #define h get_h<rotDeg>(ker)
 #define i get_i<rotDeg>(ker)
 
+#ifdef _WIN32
 #ifndef NDEBUG
 	if (breakIntoDebugger)
 		__debugbreak(); //__asm int 3;
+#endif
 #endif
 
 	const unsigned char blend = rotateBlendInfo<rotDeg>(blendInfo);
@@ -581,8 +585,10 @@ void scaleImage(const uint32_t* src, uint32_t* trg, int srcWidth, int srcHeight,
 
 		for (int x = 0; x < srcWidth; ++x, out += Scaler::scale)
 		{
+#ifdef _WIN32
 #ifndef NDEBUG
 			breakIntoDebugger = debugPixelX == x && debugPixelY == y;
+#endif
 #endif
 			//all those bounds checks have only insignificant impact on performance!
 			const int x_m1 = std::max(x - 1, 0); //perf: prefer array indexing to additional pointers!

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(core
   PatchEngine.cpp
   State.cpp
   TitleDatabase.cpp
+  UDPTLayer.h
   WiiRoot.cpp
   WiiUtils.cpp
   Boot/Boot_BS2Emu.cpp

--- a/Source/Core/DolphinWX/CMakeLists.txt
+++ b/Source/Core/DolphinWX/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SRCS
   VideoConfigDiag.cpp
   WxEventUtils.cpp
   WxUtils.cpp
+  UDPConfigDiag.cpp
 )
 
 set(LIBS

--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -155,13 +155,13 @@ void SetWindowSizeAndFitToScreen(wxTopLevelWindow* tlw, wxPoint pos, wxSize size
   if (wxDisplay::GetCount() > 1)
     screen_geometry = GetVirtualScreenGeometry();
   else
-    screen_geometry = wxDisplay(0).GetClientArea();
+    screen_geometry = wxDisplay((unsigned int)0).GetClientArea();
 
   // Initialize the default size if it is wxDefaultSize or otherwise negative.
   default_size.DecTo(screen_geometry.GetSize());
   default_size.IncTo(tlw->GetMinSize());
   if (!default_size.IsFullySpecified())
-    default_size.SetDefaults(wxDisplay(0).GetClientArea().GetSize() / 2);
+    default_size.SetDefaults((unsigned int)wxDisplay(0).GetClientArea().GetSize() / 2);
 
   // If the position we're given doesn't make sense then go with the current position.
   // (Assuming the window was created with wxDefaultPosition then this should be reasonable)

--- a/Source/Core/DolphinWX/WxUtils.cpp
+++ b/Source/Core/DolphinWX/WxUtils.cpp
@@ -161,7 +161,7 @@ void SetWindowSizeAndFitToScreen(wxTopLevelWindow* tlw, wxPoint pos, wxSize size
   default_size.DecTo(screen_geometry.GetSize());
   default_size.IncTo(tlw->GetMinSize());
   if (!default_size.IsFullySpecified())
-    default_size.SetDefaults((unsigned int)wxDisplay(0).GetClientArea().GetSize() / 2);
+    default_size.SetDefaults(wxDisplay((unsigned int)0).GetClientArea().GetSize() / 2);
 
   // If the position we're given doesn't make sense then go with the current position.
   // (Assuming the window was created with wxDefaultPosition then this should be reasonable)

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(inputcommon
   InputConfig.cpp
+  UDPWiimote.cpp
+  UDPWrapper.cpp
   ControllerEmu/ControllerEmu.cpp
   ControllerEmu/Control/Control.cpp
   ControllerEmu/Control/Input.cpp
@@ -25,6 +27,7 @@ add_library(inputcommon
 
 target_link_libraries(inputcommon PUBLIC
   common
+  wxWidgets::wxWidgets
 )
 
 if(WIN32)

--- a/Source/Core/InputCommon/UDPWiimote.cpp
+++ b/Source/Core/InputCommon/UDPWiimote.cpp
@@ -120,6 +120,13 @@ UDPWiimote::UDPWiimote(const std::string& _port, const std::string& name, int _i
       continue;
     }
 
+    //Ong: make sockets reusable in linux
+    #ifdef __linux__
+        bool my_true = 1;
+        setsockopt(sock,SOL_SOCKET,SO_REUSEADDR,&my_true,sizeof(int));
+    #endif
+
+    
     if (bind(sock, p->ai_addr, (int)p->ai_addrlen) == -1)
     {
       close(sock);


### PR DESCRIPTION
Add missing files in CMakelists.txt for Linux. In contrast to Windows, in Linux sockets must be declared reusable, otherwise UDP is stopped when a game simulation starts